### PR TITLE
fix zoom ratio for keyboard navigation

### DIFF
--- a/zoom/DESCRIPTION
+++ b/zoom/DESCRIPTION
@@ -17,8 +17,8 @@ Authors@R: c(person(given="Corentin M", family="Barbu",
     email="corentin.barbu@gmail.com", role=c("aut", "cre")),
     person(given="Sebastian", family="Gibb", role="ctb",
     email="mail@sebastiangibb.de"))
-Version: 2.0.4
-Date: 2013-11-19
+Version: 2.0.5
+Date: 2014-01-15
 Collate:
     'utils.R'
     'zoom-package.R'

--- a/zoom/NEWS
+++ b/zoom/NEWS
@@ -1,5 +1,9 @@
 RELEASE HISTORY OF THE "zoom" PACKAGE
 =====================================
+
+Version 2.0.5 [2014-01-15]:
+- Fix zoom ratio for keyboard navigation.
+
 Version 2.0.4 [2013-10-12]:
 - fix pdf print bug
 - guess format for printing in navigation mode

--- a/zoom/R/zoom-package.R
+++ b/zoom/R/zoom-package.R
@@ -3,8 +3,8 @@
 #' \tabular{ll}{
 #' Package: \tab zoom\cr
 #' Type: \tab Package\cr
-#' Version: \tab 2.0.4\cr
-#' Date: \tab 2013-11-19\cr
+#' Version: \tab 2.0.5\cr
+#' Date: \tab 2014-01-15\cr
 #' Depends: \tab R (>= 2.10.0)\cr
 #' Encoding: \tab UTF-8\cr
 #' License: \tab GPL (>= 3)\cr

--- a/zoom/R/zoom.R
+++ b/zoom/R/zoom.R
@@ -566,17 +566,17 @@ setCallBack<-function(..., xlim = NULL, ylim = NULL, xaxs = "r", yaxs = "r"){
       ## restaure initial size
       "r" = { orig.zoom(rp) },
       ## zoom in (ctrl-* == [CTRL]+[+])
-      "ctrl-*" =, "i" =,"+" = { zoomplot.zoom(fact=1.1) },
+      "ctrl-*" =, "i" =,"+" = { zoomplot.zoom(fact=10/9) },
       ## zoom out (ctrl-_ == [CTRL]+[-])
-      "ctrl-_" =, "o" =,"-" = { zoomplot.zoom(fact=0.9) },
+      "ctrl-_" =, "o" =,"-" = { zoomplot.zoom(fact=9/10) },
       ## zoom in (x-axis only)
-      "L" = { zoomplot.zoom(xlim=.zoomXlim(1.1)) },
+      "L" = { zoomplot.zoom(xlim=.zoomXlim(10/9)) },
       ## zoom out (x-axis only)
-      "H" = { zoomplot.zoom(xlim=.zoomXlim(0.9)) },
+      "H" = { zoomplot.zoom(xlim=.zoomXlim(9/10)) },
       ## zoom in (y-axis only)
-      "K" = { zoomplot.zoom(ylim=.zoomYlim(1.1)) },
+      "K" = { zoomplot.zoom(ylim=.zoomYlim(10/9)) },
       ## zoom out (y-axis only)
-      "J" = { zoomplot.zoom(ylim=.zoomYlim(0.9)) },
+      "J" = { zoomplot.zoom(ylim=.zoomYlim(9/10)) },
       ## move left
       "Left" =, "h" = { zoomplot.zoom(xlim=.moveXlim(-0.1)) },
       ## move right


### PR DESCRIPTION
Dear Corentin,

this pull request should fix the zoom ratios.
In zoom 2.0.4 the following happened:

```
plot(1:10)
zm()
# s H H s L L s
# xlim=c(1, 10), ylim=c(1, 10)
# xlim=c(-0.056, 11.056), ylim=c(1, 10)
# xlim=c(0.909, 10.091), ylim=c(1, 10)
```

After applying this fix you will get:

```
plot(1:10)
zm()
# s H H s L L s
# xlim=c(1, 10), ylim=c(1, 10)
# xlim=c(-0.056, 11.056), ylim=c(1, 10)
# xlim=c(1, 10), ylim=c(1, 10)
```

Best wishes,

Sebastian
